### PR TITLE
Increase cpu to avoid starvation

### DIFF
--- a/launch/analytics-monitor.yml
+++ b/launch/analytics-monitor.yml
@@ -8,7 +8,7 @@ env:
 - POSTGRES_PORT
 dependencies: []
 resources:
-  cpu: 0.0  # no CPU to improve resource usage (https://clever.atlassian.net/browse/INFRA-2120)
+  cpu: 0.1  # no CPU to improve resource usage (https://clever.atlassian.net/browse/INFRA-2120)
   max_mem: 0.02
 shepherds:
 expose: []


### PR DESCRIPTION
From Raf:

> 0 CPU means the worker is at the bottom of the totem pole when it comes to getting CPU time, so if it does anything remotely CPU intensive, time will effectively slow down, and there's a risk that it doesn't heartbeat in time
