### PR TITLE
chore: Updating from debian:stretch to debian:buster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,12 +3,12 @@ jobs:
   build:
     working_directory: /go/src/github.com/Clever/analytics-monitor
     docker:
-    - image: circleci/golang:1.13-stretch
+    - image: cimg/go:1.16
     - image: circleci/postgres:9.4-alpine-ram
       environment:
         GOPRIVATE: github.com/Clever/*
         POSTGRES_USER: circleci
-    - image: circleci/mongo:3.2.20-jessie-ram
+    - image: circleci/mongo:4.4
     environment:
       GOPRIVATE: github.com/Clever/*
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /go/src/github.com/Clever/analytics-monitor
     docker:
-    - image: cimg/go:1.16
+    - image: circleci/golang:1.16-buster
     - image: circleci/postgres:9.4-alpine-ram
       environment:
         GOPRIVATE: github.com/Clever/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:buster
 RUN apt-get update -y && \
     apt-get install -y ca-certificates
 


### PR DESCRIPTION
chore: Bump Dockerfile version from `debian:stretch` to `debian:buster`.

Debian Long Term Support [1] states that stretch's support ended June 30, 2022.
We were still able to perform Docker builds even while not supported. Recently,
patch files for stretch have gone missing from Debian, so we cannot use this
anymore.

Bump to the next LTS version (buster) to have builds working once again.

Auto-assigned to @mcab to merge if builds pass, and to engage with the team
that owns the repo in order to get working.

[1] https://wiki.debian.org/LTS