### PR TITLE
upgrade to go 1.21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 version: 2
 jobs:
   build:
-    working_directory: /go/src/github.com/Clever/analytics-monitor
+    working_directory: ~/go/src/github.com/Clever/analytics-monitor
     docker:
-    - image: circleci/golang:1.16-buster
+    - image: cimg/go:1.21
     - image: circleci/postgres:9.4-alpine-ram
       environment:
         GOPRIVATE: github.com/Clever/*

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
 * benji.stein@clever.com
+
+* @Clever/eng-deip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:bookworm-slim
 RUN apt-get update -y && \
     apt-get install -y ca-certificates
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ SFNCLI_VERSION := latest
 
 .PHONY: test $(PKGS) run clean vendor
 
-$(eval $(call golang-version-check,1.13))
+$(eval $(call golang-version-check,1.21))
 
 export POSTGRES_HOST=localhost
 export POSTGRES_PORT=5432

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,20 @@
 module github.com/Clever/analytics-monitor
 
-go 1.13
+go 1.21
 
 require (
 	github.com/Clever/pq v0.0.0-20210406222402-741030d37ece
 	github.com/kardianos/osext v0.0.0-20170309185600-9d302b58e975
 	github.com/stretchr/testify v1.6.1
-	github.com/xeipuuv/gojsonschema v1.2.1-0.20200424115421-065759f9c3d7 // indirect
 	gopkg.in/Clever/kayvee-go.v6 v6.24.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
+	github.com/xeipuuv/gojsonschema v1.2.1-0.20200424115421-065759f9c3d7 // indirect
 	gopkg.in/yaml.v2 v2.3.1-0.20200602174213-b893565b90ca // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/sfncli.mk
+++ b/sfncli.mk
@@ -1,10 +1,13 @@
 # This is the default sfncli Makefile.
 # Please do not alter this file directly.
-SFNCLI_MK_VERSION := 0.1.1
+SFNCLI_MK_VERSION := 0.1.2
 SHELL := /bin/bash
 SYSTEM := $(shell uname -a | cut -d" " -f1 | tr '[:upper:]' '[:lower:]')
 SFNCLI_INSTALLED := $(shell [[ -e "bin/sfncli" ]] && bin/sfncli --version)
-SFNCLI_LATEST = $(shell curl -s https://api.github.com/repos/Clever/sfncli/releases/latest | grep tag_name | cut -d\" -f4)
+# AUTH_HEADER is used to help avoid github ratelimiting
+AUTH_HEADER = $(shell [[ ! -z "${GITHUB_API_TOKEN}" ]] && echo "Authorization: token $(GITHUB_API_TOKEN)")
+SFNCLI_LATEST = $(shell \
+	curl -f -s https://api.github.com/repos/Clever/sfncli/releases | jq -r 'map(select(.prerelease)) | .[0].tag_name')
 
 .PHONY: bin/sfncli sfncli-update-makefile ensure-sfncli-version-set ensure-curl-installed
 
@@ -21,14 +24,21 @@ bin/sfncli: ensure-sfncli-version-set ensure-curl-installed
 	@mkdir -p bin
 	$(eval SFNCLI_VERSION := $(if $(filter latest,$(SFNCLI_VERSION)),$(SFNCLI_LATEST),$(SFNCLI_VERSION)))
 	@echo "Checking for sfncli updates..."
+	@# AUTH_HEADER not added to curl command below because it doesn't play well with redirects
 	@if [[ "$(SFNCLI_VERSION)" == "$(SFNCLI_INSTALLED)" ]]; then \
-		echo "Using latest sfncli version $(SFNCLI_VERSION)"; \
+		{ [[ -z "$(SFNCLI_INSTALLED)" ]] && \
+			{ echo "❌  Error: Failed to download sfncli.  Try setting GITHUB_API_TOKEN"; exit 1; } || \
+			{ echo "Using latest sfncli version $(SFNCLI_VERSION)"; } \
+		} \
 	else \
 		echo "Updating sfncli..."; \
 		curl --retry 5 --fail --max-time 30 -o bin/sfncli -sL https://github.com/Clever/sfncli/releases/download/$(SFNCLI_VERSION)/sfncli-$(SFNCLI_VERSION)-$(SYSTEM)-amd64 && \
 		chmod +x bin/sfncli && \
-		echo "Successfully updated sfncli to $(SFNCLI_LATEST)" || \
-		{ echo "Failed to update sfncli"; exit 1; } \
+		echo "Successfully updated sfncli to $(SFNCLI_VERSION)" || \
+		{ [[ -z "$(SFNCLI_INSTALLED)" ]] && \
+			{ echo "❌  Error: Failed to update sfncli"; exit 1; } || \
+			{ echo "⚠️  Warning: Failed to update sfncli using pre-existing version"; } \
+		} \
 	;fi
 
 sfncli-update-makefile: ensure-curl-installed


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/INFRANG-5737

**Overview:**
This is a combination of the go 1.21 upgrade, + sfncli and docker changes needed to avoid the glibc issue. This had to be rebased on master to avoid go.mod changes being overwritten and downgrading imports accidentally. 

**Testing:**
For this batch I will NOT be asking teams to deploy and test these changes. I will be doing that myself.
I will also be asking Infra to batch approve these instead of waiting on the teams. 
At this point we've gained a pretty high confidence in these changes and the standard failure modes. 

**Roll Out:**
Once this is merged and all other workers are merged I will be able to update sfncli master, and then go back and change the sfncli.mk code to grab "latest" again instead of the "pre-release". 
